### PR TITLE
Adding formula for `cook` cli app

### DIFF
--- a/Formula/cook.rb
+++ b/Formula/cook.rb
@@ -1,0 +1,34 @@
+class Cook < Formula
+  desc ""
+  homepage ""
+  url "https://github.com/cooklang/CookCLI.git", tag: "v0.0.8"
+  version "0.0.8"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  patch :DATA
+
+  def install
+    system "make", "prepare", "build_macos"
+    bin.install ".build/#{ENV['HOMEBREW_PROCESSOR']}-apple-macosx/release/cook"
+  end
+
+  test { system "#{bin}/cook", "version" }
+end
+
+__END__
+diff --git a/Makefile b/Makefile
+index 46f905d..ceabce1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -35,7 +35,7 @@ smoketest_linux:
+ 
+ 
+ build_macos:
+-	swift build --configuration release  --static-swift-stdlib
++	swift build --configuration release --disable-sandbox
+ 
+ archive_macos:
+ 	cd .build/x86_64-apple-macosx/release/ && zip "CookCLI_$(VERSION)_darwin_amd64.zip" cook
+


### PR DESCRIPTION
This commit adds a formula for building/installing the `cook` cli app from source. You can do `brew install --build-from-source cook`.

As a side note, I think it might be worth submitting this formula to the main homebrew repo. When the homebrew team merges a formula into its core repo, they will automatically build and serve compiled binaries for you (what they call "bottles", more at https://docs.brew.sh/Bottles).