### PR TITLE
Adding `--head` option for homebrew formula

### DIFF
--- a/Formula/cook.rb
+++ b/Formula/cook.rb
@@ -1,7 +1,7 @@
 class Cook < Formula
   desc "CLI tool for CookLang Recipe Markup Language"
   homepage "https://cooklang.org"
-  url "https://github.com/cooklang/CookCLI.git", tag: "v0.0.8"
+  url "https://github.com/cooklang/CookCLI.git", tag: "v0.0.9"
   license "MIT"
 
   head "https://github.com/cooklang/CookCLI.git", branch: "main"

--- a/Formula/cook.rb
+++ b/Formula/cook.rb
@@ -1,8 +1,7 @@
 class Cook < Formula
-  desc ""
-  homepage ""
+  desc "CLI tool for CookLang Recipe Markup Language"
+  homepage "https://cooklang.org"
   url "https://github.com/cooklang/CookCLI.git", tag: "v0.0.8"
-  version "0.0.8"
   license "MIT"
 
   depends_on xcode: ["10.0", :build]
@@ -11,7 +10,7 @@ class Cook < Formula
 
   def install
     system "make", "prepare", "build_macos"
-    bin.install ".build/#{ENV['HOMEBREW_PROCESSOR']}-apple-macosx/release/cook"
+    bin.install ".build/#{ENV["HOMEBREW_PROCESSOR"]}-apple-macosx/release/cook"
   end
 
   test { system "#{bin}/cook", "version" }

--- a/Formula/cook.rb
+++ b/Formula/cook.rb
@@ -4,6 +4,8 @@ class Cook < Formula
   url "https://github.com/cooklang/CookCLI.git", tag: "v0.0.8"
   license "MIT"
 
+  head "https://github.com/cooklang/CookCLI.git", branch: "main"
+
   depends_on xcode: ["10.0", :build]
 
   patch :DATA

--- a/Formula/cook.rb
+++ b/Formula/cook.rb
@@ -11,7 +11,7 @@ class Cook < Formula
   patch :DATA
 
   def install
-    system "make", "prepare", "build_macos"
+    system "make", "build_macos"
     bin.install ".build/#{ENV["HOMEBREW_PROCESSOR"]}-apple-macosx/release/cook"
   end
 


### PR DESCRIPTION
Hello again. This PR adds 4 things:

1. Just some fixes for the `brew audit` listing checks.
2. A `head` option to allow building of the app directly from `main` instead of at a particular tag/version. You can do that with `brew install --build-from-source --head cook`.
3. Bumped the version of `cook` to 0.0.9.
4. Removed the `make prepare` step from the build process. I misunderstood what that step was for, and it isn't needed to build the app.

Thanks!